### PR TITLE
Fix the issue with database Find, which always ignores the "distance" parameter

### DIFF
--- a/database.go
+++ b/database.go
@@ -60,7 +60,7 @@ func (d *Database) Find(hash, distance uint64) ResultSet {
 	var dist uint64
 
 	//shortcut the enumeration and do a hash lookup if the distance is zero.
-	if 0 == dist {
+	if 0 == distance {
 		for _, i := range d.hashMap[hash] {
 			rs = append(rs, &SearchResult{
 				Path:     d.entries[i].Path,


### PR DESCRIPTION
The current database's `Find` method always ignores `distance` parameter and returns only images with distance `0`. A simple fix is in the shortcut check for the case the distance is zero, use `distance`, not `dist`.